### PR TITLE
fix: prevent content from reaching upper and lower border in print

### DIFF
--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -28,7 +28,6 @@ html {
     }
     @media print {
         margin: 0;
-        height: paper_height($page-width) * $pages;
     }
 }
 
@@ -38,9 +37,9 @@ body {
 
 @media print {
     @page {
-        margin: 0;
+        margin: 12.5mm 0 25mm 0;
         size: A4;
-    }
+    }     
 }
 
 ::selection {

--- a/assets/sass/_layout.scss
+++ b/assets/sass/_layout.scss
@@ -24,11 +24,18 @@
         position: absolute;
         float: right;
         width: $width-right-col;
-        background-color: $color-right-col;
         height: 100%;
         padding: 2rem 3rem;
         right: 1rem;
 
-        @include shadow(0.5);
+        @media print {
+            border-left: 1px solid #e2e2e2;
+        }
+        
+        @media screen {
+            background-color: $color-right-col;
+            @include shadow(0.5);
+        }
+
     }
 }


### PR DESCRIPTION
Thanks for sharing this nice template.

I found that, on CVs longer than one page, content would sometimes hit the top and bottom border when printing or exporting as PDF. This PR adds top and bottom margins. (See before/after screenshots below.)

Additionally, since the margins would cover the right column's background, just for the print version I removed the background and added a thin separation line between the columns. This may be a less welcome change if you'd like to keep the web and print version very similar.

Without margins:

![without-margins](https://user-images.githubusercontent.com/19322/103290764-32e16180-49e2-11eb-8349-1089051cf9bb.png)

With margins:

![with-margins](https://user-images.githubusercontent.com/19322/103290755-2d841700-49e2-11eb-9667-50ac5f5e635b.png)



