### PR TITLE
docs: add information that Hugo Extended is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ If badges and other elements with background don't render correctly, remember to
 Clone the repo: `git clone https://github.com/ineesalmeida/almeida-cv`
 
 # Installation
-## Install Hugo
-To use almeida-cv theme you need to install Hugo by following https://gohugo.io/getting-started/installing/.
+## Install Hugo (Extended)
+To use almeida-cv theme you need to install Hugo Extended by following https://gohugo.io/getting-started/installing/.
 
 ## Create your personal website and run
 ```


### PR DESCRIPTION
I was wondering why my CV colors were not updated after changing them in config.toml.
It then turned out that I was not using Hugo Extended which seems to be required for the Sass/SCSS support.