### PR TITLE
fix: Add Crossorigin=Anonymous on theme css

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,5 +9,5 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     {{ $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "style.main.scss" . | toCSS | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}" >
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" media="screen" />
 </head>


### PR DESCRIPTION
Add crossorigin=anonymous to the theme css links to support CORS type deployment where the baseURL may be different than the URL used to see the web page (origin). For example https://rogowski.page and https://www.rogowski.page