### PR TITLE
Meta Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# OS
+.DS_Store
+._*
+
+# IDE
+.idea/
+.vscode/
+.settings/
+*.subliime-workspace
+*.sublime-project

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,2 @@
+public/
+resources/

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,15 +1,17 @@
 languageCode = "en-us"
 defaultContentLanguage = "en"
-enableRobotsTXT = "true"
-enableEmoji = "true"
+enableRobotsTXT = true
+enableEmoji = true
 
 theme = "almeida-cv"
 disableKinds = ["page", "section", "taxonomy", "term", "RSS", "sitemap"]
 
 baseURL = "https://example.com/"
 title = "Example - CV"
+#googleAnalytics = ""
 
 [params]
+enableMetaTags = true
 colorLight = "#fff"
 colorDark = "#666"
 colorPageBackground = "#ddd"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,20 +1,18 @@
+{{ $data := or (index .Site.Data .Site.Language.Lang).content .Site.Data.content }}
+{{ .Scratch.Set "data" $data }}
 <!DOCTYPE html>
 <html lang="en">
     {{ partial "head.html" . }}
 <body>
     <div class="content">
         <div class="content__left">
-            {{ $data := or (index .Site.Data .Site.Language.Lang).content .Site.Data.content }}
-            <h1 class="mainHeading">{{ $data.BasicInfo.FirstName}} <span>{{ $data.BasicInfo.LastName}}</span></h1>
-
+            <h1 class="mainHeading">{{ $data.BasicInfo.FirstName }} <span>{{ $data.BasicInfo.LastName }}</span></h1>
             {{ partial "_profile.html" $data }}
             {{ partial "_experience.html" $data }}
             {{ partial "_education.html" $data }}
             {{ partial "_references.html" $data }}
-
         </div>
         <div class="content__right">
-
             {{ partial "_avatar.html" $data }}
             {{ partial "_contacts.html" $data }}
             {{ partial "_skills.html" $data }}

--- a/layouts/partials/_profile.html
+++ b/layouts/partials/_profile.html
@@ -4,7 +4,7 @@
         <h2 class="section__title">{{ i18n "profile" }}</h2>
     </div>
     <div class="section__content">
-        <p>{{ .Profile | safeHTML }}</p>
+        <p>{{ .Profile | safeHTML | emojify }}</p>
     </div>
 </div>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,18 +1,32 @@
+{{ $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate "style.main.scss" . | toCSS | minify | fingerprint }}
+{{ $data := .Scratch.Get "data" }}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ .Site.Title }}</title>
 
+    <link rel="canonical" href="{{ .Permalink }}" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Oswald" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-
-    {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate "style.main.scss" . | toCSS | minify | fingerprint }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" media="screen,print" />
 
-    {{- if .Site.GoogleAnalytics }}
+    {{ if .Site.Params.enableMetaTags }}
+        <meta property="og:title" content="{{ .Site.Title }}" />
+        <meta property="og:url" content="{{ .Permalink }}" />
+        <meta property="og:type" content="website" />
+        {{ with $data.BasicInfo.Photo }}
+            <meta property="og:image" content="{{ . | absURL }}" />
+        {{ end }}
+        {{ with $data.Profile | htmlUnescape | emojify | truncate 200 }}
+            <meta property="og:description" content="{{ . }}" />
+            <meta name="description" content="{{ . }}" />
+        {{ end }}
+    {{ end }}
+
+    {{ if .Site.GoogleAnalytics }}
         {{ template "_internal/google_analytics.html" . }}
         {{ template "_internal/google_analytics_async.html" . }}
-    {{- end -}}
+    {{ end }}
 </head>


### PR DESCRIPTION
Hi @ineesalmeida 

In this PR you can find a support for meta tags, mostly Open Graph - for fancy thumbnails in social media, and `meta name=description` for search engines to pick it up nicely. See the examples below :blush:

Google:
![google](https://user-images.githubusercontent.com/1633387/132993540-d3c17470-f955-4615-b603-f8b0b1eb6997.png)

Facebook:
![facebook](https://user-images.githubusercontent.com/1633387/132993544-cfbc9469-3eaa-47ae-8770-19d6ec803ab7.png)

Slack:
![slack](https://user-images.githubusercontent.com/1633387/132993543-1246c16a-b7eb-472a-908c-78521f8295e7.png)