### PR TITLE
remove deprecated google analytics lines

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,8 +25,7 @@
         {{ end }}
     {{ end }}
 
-    {{ if .Site.GoogleAnalytics }}
+    {{ if .Site.Config.Services.GoogleAnalytics.ID }}
         {{ template "_internal/google_analytics.html" . }}
-        {{ template "_internal/google_analytics_async.html" . }}
     {{ end }}
 </head>


### PR DESCRIPTION
The partial/head.html uses deprecated commands for google analytics. I have update the lines following the manual.