### PR TITLE
feat (i18n): Add Chinese (simplified) translation for i18n

### DIFF
--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -1,0 +1,23 @@
+[profile]
+other = "个人简介"
+
+[experience]
+other = "工作经历"
+
+[education]
+other = "教育经历"
+
+[references]
+other = "推荐人"
+
+[skills]
+other = "技能"
+
+[languages]
+other = "语言"
+
+[diplomas]
+other = "学位"
+
+[interests]
+other = "兴趣爱好"


### PR DESCRIPTION
Greetings from a Chinese user!

A Chinese (simplified) language support is added for i18n (`zh-cn.toml` in `i18n` directory). 

`zh-cn` stands for Chinese in mainland China (Simplified Chinese). Except for `zh-cn`, there are `zh-tw` (Chinese in Taiwan, Traditional Chinese), `zh-hk` (Chinese in Hongkong, Traditional Chinese), `zh-sg` (Chinese in Singapore, Simplified Chinese). Therefore, here `zh-cn` is used instead of `zh`.