### PR TITLE
fix (page break): fix section break to avoid separating section title with content in print

### DIFF
--- a/assets/scss/components/_section.scss
+++ b/assets/scss/components/_section.scss
@@ -28,3 +28,27 @@
         }
     }
 }
+
+@media print {
+    .section {
+        page-break-inside: avoid;
+        break-inside: avoid-page;
+
+        &__heading {
+            page-break-after: avoid !important;
+            break-after: avoid-page;
+        }
+
+        &__content {
+            page-break-before: avoid;
+            break-before: avoid-page;
+
+            & > :first-child {
+                page-break-inside: avoid;
+                break-inside: avoid-page;
+                page-break-before: avoid;
+                break-before: avoid-page;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit aims to fix Issue #35 . 

Modified `_section.scss` to avoid section title is separated with its child content in page break. After the fix, it looks like:

<img width="705" height="444" alt="Screenshot_20260222_152032" src="https://github.com/user-attachments/assets/c692befd-6545-4e66-aae8-8bf6eaaadf33" />

